### PR TITLE
add created_at to v3 and fix syntax error

### DIFF
--- a/lib/delayed/backend/ironmq.rb
+++ b/lib/delayed/backend/ironmq.rb
@@ -16,6 +16,7 @@ module Delayed
         field :failed_at,   :type => Time
         field :last_error,  :type => String
         field :queue,       :type => String
+        field :created_at   :type => Time
 
         def initialize(data = {})
           @msg = nil

--- a/lib/delayed/backend/ironmq.rb
+++ b/lib/delayed/backend/ironmq.rb
@@ -16,7 +16,7 @@ module Delayed
         field :failed_at,   :type => Time
         field :last_error,  :type => String
         field :queue,       :type => String
-        field :created_at   :type => Time
+        field :created_at,  :type => Time
 
         def initialize(data = {})
           @msg = nil


### PR DESCRIPTION
We are on the v3 branch (many apologies for not mentioning that), so I cherry picked over the addition of the created_at field and added the comma which broke everything on master :)

This is in reference to: https://github.com/iron-io/delayed_job_ironmq/issues/19