### PR TITLE
Include queues specific in env vars when finding available jobs

### DIFF
--- a/lib/delayed/backend/actions.rb
+++ b/lib/delayed/backend/actions.rb
@@ -29,50 +29,6 @@ module Delayed
         #  Delayed::Worker.queue_name
         #end
 
-        def find_available(worker_name, limit = 5, max_run_time = Worker.max_run_time)
-          Delayed::IronMqBackend.available_priorities.each do |priority|
-            Delayed::IronMqBackend.all_queues.each do |queue_item|
-              message = nil
-              queue = queue_name(queue_item, priority)
-              begin
-                message = ironmq.queue(queue).get
-              rescue StandardError => e
-                if e.is_a?(Rest::HttpError) && e.code == 404
-                  # suppress Not Found errors
-                else
-                  Delayed::IronMqBackend.logger.warn(e.message)
-                end
-              end
-              return [Delayed::Backend::Ironmq::Job.new(message)] if message
-            end
-          end
-          []
-        end
-
-        def delete_all
-          Delayed::IronMqBackend.available_priorities.each do |priority|
-            loop do
-              msgs = nil
-              Delayed::IronMqBackend.queues.each do |queue_item|
-                queue = queue_name(queue_item, priority)
-                begin
-                  msgs = ironmq.queue(queue).get(:n => 100)
-                rescue StandardError => e
-                  if e.is_a?(Rest::HttpError) && e.code == 404
-                    # suppress Not Found errors
-                  else
-                    Delayed::IronMqBackend.logger.warn(e.message)
-                  end
-                end
-
-                break if msgs.blank?
-                ironmq.queue(queue).delete_reserved_messages(msgs)
-              end
-
-            end
-          end
-        end
-
         # No need to check locks
         def clear_locks!(*args)
           true

--- a/lib/delayed/backend/iron_mq_backend.rb
+++ b/lib/delayed/backend/iron_mq_backend.rb
@@ -24,8 +24,10 @@ module Delayed
         self.logger.level ||= Logger::INFO
       end
 
-      def all_queues
-        @queues.length > 0 ? @queues : [@default_queue]
+      def all_queues(worker)
+        worker_queues = worker.queues
+        combined_queues = worker_queues + @queues
+        combined_queues.length > 0 ? combined_queues : [@default_queue]
       end
     end
   end


### PR DESCRIPTION
Move `delete_all` and `find_available` into ironmq.rb and override `self.reserve` from delayed_job in order to find available jobs and reserve them. This is so that the worker can be passed to `find_available` so then we can extract the queues specified in environment variables and make them part of the queues that get queried when finding available jobs.

The `delete_all` method should probably be moved into the same location and should probably query IronMQ to get all available queues and then clear all of them, so that it matches the behaviour expected when running `rake jobs:clear`

Will close: https://github.com/iron-io/delayed_job_ironmq/issues/25
